### PR TITLE
Move to ECMAScript 5 and add url package to work smoothly with create…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const url = require('url');
+var url = require('url');
 
-const DEFAUL_OPTIONS = {
+var DEFAULT_OPTIONS = {
   target: '_blank',
   rel: 'nofollow noreferrer noopener'
 };
@@ -11,30 +11,30 @@ const DEFAUL_OPTIONS = {
  * @param href {Object} Parsed url object.
  * @return {Boolean}
  */
-const isInternal = (host, href) => {
+var isInternal = function (host, href) {
   return href.host === host || (!href.protocol && !href.host && href.pathname);
 };
 
-const remarkableExtLink = (md, options) => {
-  const config = Object.assign({}, DEFAUL_OPTIONS, options);
+var remarkableExtLink = function (md, options) {
+  var config = Object.assign({}, DEFAULT_OPTIONS, options);
 
   // Parse and normalize hostname.
   config.host = url.parse(config.host).host;
   // Save original method to invoke.
-  const originalRender = md.renderer.rules.link_open;
+  var originalRender = md.renderer.rules.link_open;
 
   md.renderer.rules.link_open = function() {
-    let result;
+    var result;
 
     // Invoke original method first.
     result = originalRender.apply(null, arguments);
 
-    let regexp = /href="([^"]*)"/;
+    var regexp = /href="([^"]*)"/;
 
-    let href = url.parse(regexp.exec(result)[1]);
+    var href = url.parse(regexp.exec(result)[1]);
 
     if (!isInternal(config.host, href)) {
-      result = result.replace('>', ` target="${config.target}" rel="${config.rel}">`);
+      result = result.replace('>', ' target="' + config.target + '" rel="' + config.rel + '">');
     }
 
     return result;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/vitaliy-bobrov/remarkable-extlink#readme",
   "dependencies": {
-    "remarkable": "^1.7.1"
+    "remarkable": "^1.7.1",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
…-react-app (and support browsers).

If you try to build an app based on `create-react-app` that uses `remarkable-extlink`, it'll fail due to this plugin using ES6 features.

This pull request fixes the plugin so that it works fine with CRA. It also adds the `url` package as a dependency as that is a `node`-specific library.