### PR TITLE
Hash link as internal URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var DEFAULT_OPTIONS = {
  * @return {Boolean}
  */
 var isInternal = function (host, href) {
-  return href.host === host || (!href.protocol && !href.host && href.pathname);
+  return href.host === host || (!href.protocol && !href.host && (href.pathname || href.hash));
 };
 
 var remarkableExtLink = function (md, options) {


### PR DESCRIPTION
As of now if the link only contains hash like `<a href="#example">example</a>` it is marked as external link whereas it is an internal link (Link of the same page)